### PR TITLE
조건 중복 검사 삭제

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,13 +296,9 @@ app.on("ready", ()=> {
     });
 
     function checkPossible(res, filename){
-        if(!shareData.share){
+        if(!shareData.share) {
             sendError(res, "현재 서버에서 데이터를 공유하고 있지 않습니다");
             return false;
-        }
-
-        if(!shareData.share){
-            sendError(res, "현재 공유중이지 않습니다."); return false;
         }
 
         if(filename === undefined) {


### PR DESCRIPTION
### 이슈
* shareData.share 의 상태를 두번 확인함

### 해결
sharedata.share 에 대한 체크가 두번 이루어지고 있어서
sharedata.share 가 false 인 경우 접근이 불가능한 코드를 삭제했습니다.